### PR TITLE
fix: add oauth

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,3 +1,4 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
+src/index.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * as Squidex from "./api";
-export { SquidexClient } from "./Client";
+export { SquidexClient } from "./wrapper/SquidexClient";
 export { SquidexEnvironment } from "./environments";
 export { SquidexError, SquidexTimeoutError } from "./errors";

--- a/src/wrapper/SquidexClient.ts
+++ b/src/wrapper/SquidexClient.ts
@@ -1,0 +1,69 @@
+import { SquidexClient as FernClient } from "../Client";
+import * as environments from "../environments";
+import * as core from "../core";
+import * as errors from "../errors";
+import urlJoin from "url-join";
+
+export declare namespace SquidexClient {
+    interface Options {
+        clientId: string;
+        clientSecret: string;
+        environment?: environments.SquidexEnvironment | string;
+    }
+}
+
+export class SquidexClient extends FernClient {
+    private token: string | undefined;
+
+    constructor(options: SquidexClient.Options) {
+        super({
+            environment: options.environment,
+            token: async () => {
+                if (this.token == null) {
+                    const response = await core.fetcher({
+                        url: urlJoin(
+                            this.options.environment ?? environments.SquidexEnvironment.Default,
+                            "/identity-server/connect/token"
+                        ),
+                        contentType: "application/x-www-form-urlencoded",
+                        method: "POST",
+                        body: {
+                            grant_type: "client_credentials",
+                            client_id: options.clientId,
+                            client_secret: options.clientSecret,
+                            scope: "squidex-api",
+                        },
+                    });
+                    if (response.ok) {
+                        if (typeof response.body !== "string") {
+                            throw new errors.SquidexError({
+                                message: "Token is not a string",
+                            });
+                        }
+                        this.token = response.body;
+                    } else {
+                        switch (response.error.reason) {
+                            case "non-json":
+                                throw new errors.SquidexError({
+                                    statusCode: response.error.statusCode,
+                                    body: response.error.rawBody,
+                                });
+                            case "timeout":
+                                throw new errors.SquidexTimeoutError();
+                            case "unknown":
+                                throw new errors.SquidexError({
+                                    message: response.error.errorMessage,
+                                });
+                        }
+                    }
+                }
+                if (this.token == null) {
+                    throw new errors.SquidexError({
+                        message: "Token is null despite trying to fetch",
+                    });
+                }
+                return this.token;
+            },
+        });
+    }
+}


### PR DESCRIPTION
This PR extends the Fern generated client with a new class that takes `clientId` and `clientSecret` and does oauth for you. 