### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4.1.0
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.1
 
       - name: Compile
         run: yarn && yarn build
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.1.0
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.1
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.1](https://github.com/actions/setup-node/releases/tag/v4.0.1)** on 2023-12-18T11:05:34Z
