### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4.1.0
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.3
 
       - name: Compile
         run: yarn && yarn build
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.1.0
 
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4.0.3
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: tests
 
       - name: Test - RUN
-        uses: kohlerdominik/docker-run-action@v1.1.0
+        uses: kohlerdominik/docker-run-action@v2.0.0
         with:
           image: node
           environment: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.3](https://github.com/actions/setup-node/releases/tag/v4.0.3)** on 2024-07-09T14:22:34Z
* **[kohlerdominik/docker-run-action](https://github.com/kohlerdominik/docker-run-action)** published a new release **[v2.0.0](https://github.com/kohlerdominik/docker-run-action/releases/tag/v2.0.0)** on 2024-02-27T16:41:17Z
