### PR TITLE
Add getToken

### DIFF
--- a/src/wrapper/SquidexClient.ts
+++ b/src/wrapper/SquidexClient.ts
@@ -326,6 +326,13 @@ export class SquidexClients {
     clearToken() {
         this.tokenStore.clear();
     }
+
+    /**
+     * Get an access token from the token store. If it doesn't exist, request it and save it to the token store
+     */
+    getToken() {
+        return this.tokenApi.getToken();
+    }
 }
 
 function addOptions(init: RequestInit, clientOptions: SquidexOptions) {


### PR DESCRIPTION
This PR adds a new function to fetch an authentication token for use cases that only require the token itself.

**problem**
The problem is that there is no way to get the authentication token without a single API call.
I was trying to inject only the authentication token into ApolloClient, but I stumbled upon this issue.